### PR TITLE
feat: monitoramento e mensageria via docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,20 @@ export class UsersController extends Controller {
 - **Documentação Swagger**: <http://localhost:3000/api-docs>
 - **Health Check**: <http://localhost:3000/health>
 
+## 📈 Monitoramento e Serviços Adicionais
+
+O `docker-compose` agora provisiona serviços extras para observabilidade e fila/mensagem:
+
+- **Redis** (cache): `localhost:6379`
+- **RabbitMQ**: `localhost:5672` (UI em `http://localhost:15672`)
+- **Prometheus**: <http://localhost:9090>
+- **Grafana**: <http://localhost:3001>
+- **Loki**: <http://localhost:3100>
+- **Jaeger**: <http://localhost:16686>
+
+Esses componentes permitem coleta de métricas, logs e traces distribuídos.
+Para configurações avançadas consulte [docs/OBSERVABILIDADE.md](docs/OBSERVABILIDADE.md).
+
 ## 🔒 Segurança e Boas Práticas
 
 Este projeto implementa:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,6 @@ services:
     networks:
       - monorepo-network
 
-  # Optional: Redis for caching/sessions
   redis:
     image: redis:7-alpine
     container_name: monorepo-ngxp-redis
@@ -39,7 +38,71 @@ services:
     networks:
       - monorepo-network
 
-  # Optional: Adminer for database management
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: monorepo-ngxp-rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - monorepo-network
+
+  prometheus:
+    image: prom/prometheus
+    container_name: monorepo-ngxp-prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+    networks:
+      - monorepo-network
+
+  loki:
+    image: grafana/loki:2.9.4
+    container_name: monorepo-ngxp-loki
+    command: -config.file=/etc/loki/local-config.yaml
+    ports:
+      - "3100:3100"
+    volumes:
+      - loki_data:/loki
+    restart: unless-stopped
+    networks:
+      - monorepo-network
+
+  grafana:
+    image: grafana/grafana
+    container_name: monorepo-ngxp-grafana
+    ports:
+      - "3001:3000"
+    depends_on:
+      - prometheus
+      - loki
+    volumes:
+      - grafana_data:/var/lib/grafana
+    restart: unless-stopped
+    networks:
+      - monorepo-network
+
+  jaeger:
+    image: jaegertracing/all-in-one
+    container_name: monorepo-ngxp-jaeger
+    ports:
+      - "16686:16686"
+      - "6831:6831/udp"
+    restart: unless-stopped
+    networks:
+      - monorepo-network
+
   adminer:
     image: adminer:4
     container_name: monorepo-ngxp-adminer
@@ -57,6 +120,14 @@ volumes:
   postgres_data:
     driver: local
   redis_data:
+    driver: local
+  rabbitmq_data:
+    driver: local
+  prometheus_data:
+    driver: local
+  loki_data:
+    driver: local
+  grafana_data:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   api:
     build:
@@ -119,6 +121,7 @@ services:
     restart: unless-stopped
 
 volumes:
+
   postgres_data:    driver: local
   redis_data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,11 @@ services:
     environment:
       - NODE_ENV=production
       - DATABASE_URL=postgres://user:password@db:5432/mydatabase
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
     depends_on:
       - db
+      - jaeger
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 30s
@@ -52,6 +55,78 @@ services:
       retries: 5
     restart: unless-stopped
 
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:2.9.4
+    command: -config.file=/etc/loki/local-config.yaml
+    ports:
+      - "3100:3100"
+    volumes:
+      - loki_data:/loki
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3001:3000"
+    depends_on:
+      - prometheus
+      - loki
+    volumes:
+      - grafana_data:/var/lib/grafana
+    restart: unless-stopped
+
+  jaeger:
+    image: jaegertracing/all-in-one
+    ports:
+      - "16686:16686"
+      - "6831:6831/udp"
+    restart: unless-stopped
+
 volumes:
-  postgres_data:
+  postgres_data:    driver: local
+  redis_data:
+    driver: local
+  rabbitmq_data:
+    driver: local
+  prometheus_data:
+    driver: local
+  loki_data:
+    driver: local
+  grafana_data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,8 @@ services:
 
 volumes:
 
-  postgres_data:    driver: local
+  postgres_data:    
+    driver: local
   redis_data:
     driver: local
   rabbitmq_data:

--- a/docs/DEVCONTAINER.md
+++ b/docs/DEVCONTAINER.md
@@ -74,6 +74,13 @@ Ctrl+Shift+P (Cmd+Shift+P no Mac)
 | 3000 | API Express | http://localhost:3000 |
 | 4200 | Angular Dev | http://localhost:4200 |
 | 5432 | PostgreSQL | localhost:5432 |
+| 6379 | Redis | localhost:6379 |
+| 5672 | RabbitMQ | localhost:5672 |
+| 15672 | RabbitMQ UI | http://localhost:15672 |
+| 9090 | Prometheus | http://localhost:9090 |
+| 3001 | Grafana | http://localhost:3001 |
+| 3100 | Loki | http://localhost:3100 |
+| 16686 | Jaeger | http://localhost:16686 |
 | 8080 | Adminer DB | http://localhost:8080 |
 
 ## 🔥 Aliases úteis (terminal)

--- a/docs/OBSERVABILIDADE.md
+++ b/docs/OBSERVABILIDADE.md
@@ -1,0 +1,27 @@
+# Monitoramento e Observabilidade
+
+Este projeto inclui uma stack completa de monitoramento via **Grafana**, **Loki**, **Prometheus** e **Jaeger**.
+
+## Serviços
+
+- **Prometheus** coleta métricas da API.
+- **Grafana** exibe dashboards e consome dados do Prometheus e Loki.
+- **Loki** centraliza logs de aplicações.
+- **Jaeger** registra traces distribuídos.
+- **Redis** fornece cache rápido.
+- **RabbitMQ** gerencia filas de mensagens.
+
+Todos os serviços são iniciados automaticamente pelo `docker-compose`.
+
+## Acessos Rápidos
+
+| Serviço | URL |
+|---------|-----|
+| Prometheus | <http://localhost:9090> |
+| Grafana | <http://localhost:3001> |
+| Loki | <http://localhost:3100> |
+| Jaeger | <http://localhost:16686> |
+| Redis | `localhost:6379` |
+| RabbitMQ | `localhost:5672` (UI <http://localhost:15672>) |
+
+Essas ferramentas permitem análise de performance, coleta de métricas e rastreamento de requisições de maneira integrada.

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'api'
+    static_configs:
+      - targets: ['api:3000']


### PR DESCRIPTION
## Summary
- adicionar stack Grafana + Loki + Prometheus + Jaeger
- incluir Redis e RabbitMQ
- documentar novas portas e serviços

## Testing
- `npm test` *(fails: jest/ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da51507a083259d3a3d7407ae9c5b