### PR TITLE
Fix linting error from test bootstrap file

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -10,7 +10,7 @@ export default [
   js.configs.recommended,
   {
     files: ['**/*.ts'],
-    ignores: ['**/*.spec.ts', 'dist/**/*', 'node_modules/**/*', 'src/environments/environment.prod.ts'],
+    ignores: ['**/*.spec.ts', 'src/test.ts', 'dist/**/*', 'node_modules/**/*', 'src/environments/environment.prod.ts'],
     languageOptions: {
       parser: tsParser,
       parserOptions: {


### PR DESCRIPTION
## Summary
- ignore Angular's bootstrap test file to avoid lint parsing errors

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js' & `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da8461d64832580356752d088f714