### PR TITLE
Fix Dockerfile CMD instruction

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -26,5 +26,6 @@ WORKDIR /usr/src/app/apps/api
 EXPOSE 3000
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:3000/health || exit 1# Start the applicationCMD ["node", "dist/server.js"]
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \  CMD curl -f http://localhost:3000/health || exit 1
+# Start the application
+CMD ["node", "dist/server.js"]


### PR DESCRIPTION
## Summary
- split the CMD instruction in the API Dockerfile

## Testing
- `docker-compose build api` *(fails: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686daedc95cc832590da00ac686d3a91